### PR TITLE
Update Calculate_Tag.m

### DIFF
--- a/eSpectra_Module/Calculate_Tag.m
+++ b/eSpectra_Module/Calculate_Tag.m
@@ -165,8 +165,16 @@ ES_Obj.Spectrum = ES_Obj.Spectrum/max(ES_Obj.Spectrum);
 ES_Obj.nSpectra = size(handles.Spectrum(:,handles.Chosen_ES),2);
 Spc             = ES_Obj.Spectrum;
 WL              = ES_Obj.Wavelength;
+
+%{
+Edited by Thomas Killeen 2022-11-08
+Multiplying by the term D_WL was resulting in an artificially inflated spectral integral
+value. By multiplying by the width (or distance) between wavelengths the
+intensity value for each wavelength was "double counted" so to speak.
 D_WL            = WL(2:end)-WL(1:end-1);
 ES_Obj.Spectral_Integral = sum(D_WL.*(Spc(1:end-1)+Spc(2:end))/2);
+%}
+ES_Obj.Spectral_Integral = sum((Spc(1:end-1)+Spc(2:end))/2);
 ES_Obj.Spectral_Integral(ES_Obj.Spectral_Integral<0) = -ES_Obj.Spectral_Integral;
 handles.ES_Item_Folder   = uigetdir('','Save Spectrum to');
 ES_Obj.Path     = handles.ES_Item_Folder;


### PR DESCRIPTION
The spectral integral was calculated incorrectly when .tag files were being generated. There was a double counting issue due to the summation of wavelengths. This issue is corrected in this branch.

I believe this branch is ready to be merged with main.